### PR TITLE
Feature: Thorfile for versioning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,8 @@ gemspec
 # FIXME
 ## Change this when the gem is published to Rubygems
 gem 'daemon_runner', git: 'git@github.com:rapid7/daemon_runner.git', ref: '0.1.0'
+
+group :development do
+  gem 'bundler', '~> 1.7'
+  gem 'thor-scmversion', '= 1.7.0'
+end

--- a/Thorfile
+++ b/Thorfile
@@ -1,0 +1,5 @@
+# encoding: utf-8
+
+require 'bundler'
+require 'bundler/setup'
+require 'thor/scmversion'


### PR DESCRIPTION
This adds a Thorfile with the [thor-scmversion](https://github.com/RiotGamesMinions/thor-scmversion) plugin to make it easier to bump version numbers as part of a CI job.