### PR TITLE
Feature: Health status

### DIFF
--- a/lib/cassandra/utils/daemon.rb
+++ b/lib/cassandra/utils/daemon.rb
@@ -6,6 +6,7 @@ module Cassandra
 
       def tasks
         [
+          [::Cassandra::Utils::Stats::Health.new, 'run!'],
           [::Cassandra::Utils::Stats::Compaction.new, 'run!'],
           [::Cassandra::Utils::Stats::Cleanup.new, 'run!']
         ]

--- a/lib/cassandra/utils/stats.rb
+++ b/lib/cassandra/utils/stats.rb
@@ -1,2 +1,3 @@
 require_relative 'stats/compaction'
 require_relative 'stats/cleanup'
+require_relative 'stats/health'

--- a/lib/cassandra/utils/stats/health.rb
+++ b/lib/cassandra/utils/stats/health.rb
@@ -4,13 +4,32 @@ module Cassandra
       class Health < Utils::CLI::Base
         def run!
           running = true
-          running &= nodetool_statusgossip.strip.include?('running')
-          running &= nodetool_statusthrift.strip.include?('running')
-          to_dd(running)
+          running &= nodetool_statusgossip.strip == 'running'
+          running &= nodetool_statusthrift.strip == 'running'
+          running &= state == :normal
+          running = to_dd running
+          push_metric running
+          running
         end
 
         def metric_name
           'cassandra.service.running'
+        end
+
+        # Return the state of the Cassandra node
+        #
+        # The returned state is reported by "nodetool netstats".
+        #
+        # @return [state, nil]
+        #
+        def state
+          results = (nodetool_netstats || '').split("\n")
+          results.map! { |line| line.strip }
+          results.select! { |line| line.include? 'Mode:' }
+          results.map! { |line| line.split(':')[1] }
+          results.compact!
+          return nil if results.size != 1
+          results.first.strip.downcase.to_sym
         end
 
         private
@@ -33,6 +52,16 @@ module Cassandra
           @nodetool_statusthrift||= DaemonRunner::ShellOut.new(command: 'nodetool statusthrift')
           @nodetool_statusthrift.run!
           @nodetool_statusthrift.stdout
+        end
+
+        # Run the "nodetool netstats' command and return the output
+        #
+        # @return [String, nil] Output from the "nodetool netstats" command
+        #
+        def nodetool_netstats
+          @nodetool_netstats ||= DaemonRunner::ShellOut.new(command: 'nodetool netstats', timeout: 120)
+          @nodetool_netstats.run!
+          @nodetool_netstats.stdout
         end
       end
     end

--- a/lib/cassandra/utils/stats/health.rb
+++ b/lib/cassandra/utils/stats/health.rb
@@ -4,9 +4,10 @@ module Cassandra
       class Health < Utils::CLI::Base
         def run!
           running = true
-          running &= nodetool_statusgossip.strip == 'running'
-          running &= nodetool_statusthrift.strip == 'running'
-          running &= state == :normal
+          if state == :normal
+            running &&= nodetool_statusgossip.strip == 'running'
+            running &&= nodetool_statusthrift.strip == 'running'
+          end
           running = to_dd running
           push_metric running
           running

--- a/lib/cassandra/utils/stats/health.rb
+++ b/lib/cassandra/utils/stats/health.rb
@@ -1,0 +1,40 @@
+module Cassandra
+  module Utils
+    module Stats
+      class Health < Utils::CLI::Base
+        def run!
+          running = true
+          running &= nodetool_statusgossip.strip.include?('running')
+          running &= nodetool_statusthrift.strip.include?('running')
+          to_dd(running)
+        end
+
+        def metric_name
+          'cassandra.service.running'
+        end
+
+        private
+
+        # Run the "nodetool statusgossip' command and return the output
+        #
+        # @return [String, nil] Output from the "nodetool statusgossip" command
+        #
+        def nodetool_statusgossip
+          @nodetool_statusgossip ||= DaemonRunner::ShellOut.new(command: 'nodetool statusgossip')
+          @nodetool_statusgossip.run!
+          @nodetool_statusgossip.stdout
+        end
+
+        # Run the "nodetool statusthrift' command and return the output
+        #
+        # @return [String, nil] Output from the "nodetool statusthrift" command
+        #
+        def nodetool_statusthrift
+          @nodetool_statusthrift||= DaemonRunner::ShellOut.new(command: 'nodetool statusthrift')
+          @nodetool_statusthrift.run!
+          @nodetool_statusthrift.stdout
+        end
+      end
+    end
+  end
+end

--- a/test/cassandra/health_check_test.rb
+++ b/test/cassandra/health_check_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+describe Cassandra::Utils::Stats::Health do
+  before do
+    @checker = Cassandra::Utils::Stats::Health.new
+  end
+
+  describe :run! do
+    it 'succeeds if node is normal and thrift and gossip are running' do
+      @checker.stub :nodetool_netstats, 'Mode: NORMAL' do
+        @checker.stub :nodetool_statusthrift, 'running' do
+          @checker.stub :nodetool_statusgossip, 'running' do
+            @checker.run!.must_equal 1
+          end
+        end
+      end
+    end
+
+    it 'fails if gossip is down' do
+      @checker.stub :nodetool_netstats, 'Mode: NORMAL' do
+        @checker.stub :nodetool_statusgossip, 'down' do
+          @checker.stub :nodetool_statusthrift, 'running' do
+            @checker.run!.must_equal 0
+          end
+        end
+      end
+    end
+
+    it 'fails if thrift is down' do
+      @checker.stub :nodetool_netstats, 'Mode: NORMAL' do
+        @checker.stub :nodetool_statusthrift, 'down' do
+          @checker.stub :nodetool_statusgossip, 'running' do
+            @checker.run!.must_equal 0
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/cassandra/health_check_test.rb
+++ b/test/cassandra/health_check_test.rb
@@ -38,11 +38,7 @@ describe Cassandra::Utils::Stats::Health do
 
     it 'skips thrift and gossip checks if node is not NORMAL' do
       @checker.stub :nodetool_netstats, 'Mode: JOINING' do
-        @checker.stub :nodetool_statusthrift, 'down' do
-          @checker.stub :nodetool_statusgossip, 'down' do
-            @checker.run!.must_equal 1
-          end
-        end
+        @checker.run!.must_equal 1
       end
     end
   end

--- a/test/cassandra/health_check_test.rb
+++ b/test/cassandra/health_check_test.rb
@@ -6,7 +6,7 @@ describe Cassandra::Utils::Stats::Health do
   end
 
   describe :run! do
-    it 'succeeds if node is normal and thrift and gossip are running' do
+    it 'succeeds if node is NORMAL and thrift and gossip are running' do
       @checker.stub :nodetool_netstats, 'Mode: NORMAL' do
         @checker.stub :nodetool_statusthrift, 'running' do
           @checker.stub :nodetool_statusgossip, 'running' do
@@ -31,6 +31,16 @@ describe Cassandra::Utils::Stats::Health do
         @checker.stub :nodetool_statusthrift, 'down' do
           @checker.stub :nodetool_statusgossip, 'running' do
             @checker.run!.must_equal 0
+          end
+        end
+      end
+    end
+
+    it 'skips thrift and gossip checks if node is not NORMAL' do
+      @checker.stub :nodetool_netstats, 'Mode: JOINING' do
+        @checker.stub :nodetool_statusthrift, 'down' do
+          @checker.stub :nodetool_statusgossip, 'down' do
+            @checker.run!.must_equal 1
           end
         end
       end


### PR DESCRIPTION
This adds a health status check for Cassandra. Similar to the compaction and cleanup status checks, it writes a 1 or 0 to Datadog. A 1 indicates a healthy node. A 0 indicates an unhealthy node. A healthy node is one that is in a NORMAL status and has both thrift and gossip running. Nodes are considered healthy by default, so a node in a JOINING or DECOMMISSIONING phase won't report as unhealthy.