### PR TITLE
Fixes writing to token_cache

### DIFF
--- a/lib/cassandra/tasks/autoclean.rb
+++ b/lib/cassandra/tasks/autoclean.rb
@@ -227,7 +227,7 @@ module Cassandra
      # @return [File] File where tokens wil be saved
      #
      def token_cache
-       File.new(token_cache_path)
+       File.new(token_cache_path, 'w+')
      end
    end
   end

--- a/lib/cassandra/tasks/autoclean.rb
+++ b/lib/cassandra/tasks/autoclean.rb
@@ -83,7 +83,7 @@ module Cassandra
      # @return [Array<String>] Cached tokens
      #
      def cached_tokens
-       data = File.read token_cache
+       data = token_cache.read
        data = JSON.parse data
        return [] unless data['version'] == ::Cassandra::Utils::VERSION
 


### PR DESCRIPTION
We were not opening the `token_cache` for writing in the autoclean code, the tests however were opening the file for writing so they all passed.

This change exposes the file mode more apparent.