### PR TITLE
Adds cleanup task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in cassandra-utils.gemspec
 gemspec
 
+# TODO: Remove this when the next version of diplomat is released
+gem 'diplomat', github: 'WeAreFarmGeek/diplomat', ref: 'e64b0dec3b3616ded40bb64139a388dfc1a68232'
+
 group :development do
   gem 'bundler', '~> 1.7'
   gem 'thor-scmversion', '= 1.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: git://github.com/WeAreFarmGeek/diplomat.git
+  revision: e64b0dec3b3616ded40bb64139a388dfc1a68232
+  ref: e64b0dec3b3616ded40bb64139a388dfc1a68232
+  specs:
+    diplomat (1.1.0)
+      faraday (~> 0.9)
+      json
+
 PATH
   remote: .
   specs:
@@ -10,16 +19,14 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    daemon_runner (0.3.0)
+    daemon_runner (0.4.0)
       diplomat (~> 1.0)
       logging (~> 2.1)
       mixlib-shellout (~> 2.2)
+      retryable (~> 2.0)
       rufus-scheduler (~> 3.2)
-    diplomat (1.0.0)
-      faraday (~> 0.9)
-      json
     dogstatsd-ruby (1.6.0)
-    faraday (0.9.2)
+    faraday (0.10.0)
       multipart-post (>= 1.2, < 3)
     json (2.0.2)
     little-plugger (1.1.4)
@@ -31,6 +38,7 @@ GEM
     multi_json (1.12.1)
     multipart-post (2.0.0)
     rake (10.5.0)
+    retryable (2.0.4)
     rufus-scheduler (3.2.2)
     thor (0.19.1)
     thor-scmversion (1.7.0)
@@ -43,6 +51,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.7)
   cassandra-utils!
+  diplomat!
   minitest (~> 5.0)
   rake (~> 10.0)
   thor-scmversion (= 1.7.0)

--- a/bin/cass-util
+++ b/bin/cass-util
@@ -4,13 +4,18 @@ require 'thor'
 
 class CassandraUtils < Thor
 
-  method_option :loop_sleep_time, type: :numeric,
+  class_option :loop_sleep_time, type: :numeric,
     required: true, default: 120,
     desc: 'Frequency tasks are run'
-  desc 'stats', 'Write metrics to Datadog'
-  def stats
+  desc 'util', 'Perform various utilities'
+  def util
     s = ::Cassandra::Utils::Daemon.new(options)
     s.start!
+  end
+  # Backwards compatibility
+  desc 'stats', '[DEPRECATED - Use util] Write metrics to Datadog'
+  def stats
+    send(:util)
   end
 end
 

--- a/bin/cass-util
+++ b/bin/cass-util
@@ -7,6 +7,12 @@ class CassandraUtils < Thor
   class_option :loop_sleep_time, type: :numeric,
     required: true, default: 120,
     desc: 'Frequency tasks are run'
+  class_option :cleanup_service_name, type: :string,
+    required: true, default: 'cassandra',
+    desc: 'Unique string to be used in obtaining a Semaphore.  Example: cassandra-#{cluster_name}'
+  class_option :cleanup_lock_count, type: :numeric,
+    required: true, default: 1,
+    desc: 'Number of nodes that can obtain a Semaphore lock'
   desc 'util', 'Perform various utilities'
   def util
     s = ::Cassandra::Utils::Daemon.new(options)

--- a/bin/cass-util
+++ b/bin/cass-util
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 require_relative '../lib/cassandra/utils'
+require_relative '../lib/cassandra/tasks'
 require 'thor'
 
 class CassandraUtils < Thor

--- a/lib/cassandra/utils/daemon.rb
+++ b/lib/cassandra/utils/daemon.rb
@@ -6,10 +6,17 @@ module Cassandra
 
       def tasks
         [
+          [auto_clean_task, 'run!'],
           [::Cassandra::Utils::Stats::Health.new, 'run!'],
           [::Cassandra::Utils::Stats::Compaction.new, 'run!'],
           [::Cassandra::Utils::Stats::Cleanup.new, 'run!']
         ]
+      end
+
+      private
+
+      def auto_clean_task
+        @auto_clean_task ||= ::Cassandra::Tasks::Autoclean.new(options)
       end
     end
   end

--- a/lib/cassandra/utils/daemon.rb
+++ b/lib/cassandra/utils/daemon.rb
@@ -7,9 +7,9 @@ module Cassandra
       def tasks
         [
           [auto_clean_task, 'run!'],
-          [::Cassandra::Utils::Stats::Health.new, 'run!'],
-          [::Cassandra::Utils::Stats::Compaction.new, 'run!'],
-          [::Cassandra::Utils::Stats::Cleanup.new, 'run!']
+          [health_stat, 'run!'],
+          [compaction_stat, 'run!'],
+          [cleanup_stat, 'run!']
         ]
       end
 
@@ -17,6 +17,18 @@ module Cassandra
 
       def auto_clean_task
         @auto_clean_task ||= ::Cassandra::Tasks::Autoclean.new(options)
+      end
+
+      def health_stat
+        @health_stat ||= ::Cassandra::Utils::Stats::Health.new
+      end
+
+      def compaction_stat
+        @compaction_stat ||= ::Cassandra::Utils::Stats::Compaction.new
+      end
+
+      def cleanup_stat
+        @cleanup_stat ||= ::Cassandra::Utils::Stats::Cleanup.new
       end
     end
   end


### PR DESCRIPTION
This change adds the autoclean task in a semaphore lock.

You may want to change `cleanup_service_name ` and `cleanup_lock_count` to fit your needs, as these settings control how the semaphore lock is obtained. 