### PR TITLE
Push metric when we start cleanup

### DIFF
--- a/lib/cassandra/tasks/autoclean.rb
+++ b/lib/cassandra/tasks/autoclean.rb
@@ -192,11 +192,17 @@ module Cassandra
      #
      def nodetool_cleanup
        pid = find_nodetool_cleanup
-       logger.debug "Found nodetool cleanup process #{pid} already running" unless pid.nil?
-       pid = exec_nodetool_cleanup if pid.nil?
-       logger.debug "Started nodetool cleanup process #{pid}" if pid
-       status = wait_nodetool_cleanup pid
-       logger.debug "Completed nodetool cleanup process #{pid}" if pid
+       if pid
+         logger.debug "Found nodetool cleanup process #{pid} already running"
+         Utils::Statsd.new('cassandra.cleanup.running').push!(1)
+       end
+       pid = exec_nodetool_cleanup
+       if pid
+         logger.debug "Started nodetool cleanup process #{pid}"
+         Utils::Statsd.new('cassandra.cleanup.running').push!(1)
+         status = wait_nodetool_cleanup pid
+         logger.debug "Completed nodetool cleanup process #{pid}"
+       end
        status
      end
 

--- a/lib/cassandra/utils.rb
+++ b/lib/cassandra/utils.rb
@@ -1,3 +1,4 @@
 require_relative 'utils/cli/base'
 require_relative 'utils/daemon'
+require_relative 'utils/statsd'
 require_relative 'utils/stats'

--- a/lib/cassandra/utils/cli/base.rb
+++ b/lib/cassandra/utils/cli/base.rb
@@ -1,5 +1,4 @@
 require 'mixlib/shellout'
-require 'statsd'
 
 module Cassandra
   module Utils
@@ -31,20 +30,6 @@ module Cassandra
           out = output
           push_metric(out)
           out
-        end
-
-        protected
-
-        def statsd
-          @statsd ||= ::Statsd.new('localhost', 8125)
-        end
-
-        def push_metric(value)
-          statsd.gauge(metric_name, value)
-        end
-
-        def to_dd(out)
-          out == true ? 1 : 0
         end
       end
     end

--- a/lib/cassandra/utils/cli/base.rb
+++ b/lib/cassandra/utils/cli/base.rb
@@ -28,7 +28,7 @@ module Cassandra
           @command.error!
           @stdout = @command.stdout
           out = output
-          push_metric(out)
+          Utils::Statsd.new(metric_name).to_dd(out).push!
           out
         end
       end

--- a/lib/cassandra/utils/stats/cleanup.rb
+++ b/lib/cassandra/utils/stats/cleanup.rb
@@ -9,7 +9,6 @@ module Cassandra
 
         def output
           cleanup = stdout.lines.any? { |l| l.include?('Cleanup') }
-          to_dd(cleanup)
         end
 
         def metric_name

--- a/lib/cassandra/utils/stats/compaction.rb
+++ b/lib/cassandra/utils/stats/compaction.rb
@@ -9,7 +9,6 @@ module Cassandra
 
         def output
           compaction = stdout.lines.any? { |l| l.include?('Compaction') }
-          to_dd(compaction)
         end
 
         def metric_name

--- a/lib/cassandra/utils/stats/health.rb
+++ b/lib/cassandra/utils/stats/health.rb
@@ -8,8 +8,7 @@ module Cassandra
             running &&= nodetool_statusgossip.strip == 'running'
             running &&= nodetool_statusthrift.strip == 'running'
           end
-          running = to_dd running
-          push_metric running
+          Utils::Statsd.new(metric_name).to_dd(running).push!
           running
         end
 

--- a/lib/cassandra/utils/statsd.rb
+++ b/lib/cassandra/utils/statsd.rb
@@ -1,0 +1,24 @@
+require 'statsd'
+
+module Cassandra
+  module Utils
+    class Statsd
+      attr_reader :statsd, :metric_name, :value
+
+      def initialize(metric_name)
+        @statsd ||= ::Statsd.new('localhost', 8125)
+        @metric_name = metric_name
+        self
+      end
+
+      def to_dd(value)
+        @value = (value == true ? 1 : 0)
+        self
+      end
+
+      def push!(value = @value)
+        statsd.gauge(metric_name, value)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change will push a metric when we start a cleanup so that we don't have to wait for the normal task cycle to know that a cleanup has started.