### PR TITLE
Try to address nodetool command timeouts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    daemon_runner (0.4.0)
+    daemon_runner (0.4.1)
       diplomat (~> 1.0)
       logging (~> 2.1)
       mixlib-shellout (~> 2.2)

--- a/lib/cassandra/tasks/autoclean.rb
+++ b/lib/cassandra/tasks/autoclean.rb
@@ -242,6 +242,10 @@ module Cassandra
      def token_cache
        File.new(token_cache_path, 'w+')
      end
+
+     def task_id
+       ['autoclean', 'nodetool']
+     end
    end
   end
 end

--- a/lib/cassandra/tasks/autoclean.rb
+++ b/lib/cassandra/tasks/autoclean.rb
@@ -151,6 +151,10 @@ module Cassandra
        @address
      end
 
+     def task_id
+       ['autoclean', 'nodetool']
+     end
+
      private
 
      # Run the "nodetool ring" command and return the output
@@ -241,10 +245,6 @@ module Cassandra
      #
      def token_cache
        File.new(token_cache_path, 'w+')
-     end
-
-     def task_id
-       ['autoclean', 'nodetool']
      end
    end
   end

--- a/lib/cassandra/tasks/autoclean.rb
+++ b/lib/cassandra/tasks/autoclean.rb
@@ -158,7 +158,7 @@ module Cassandra
      # @return [String, nil] Output from the "nodetool ring" command
      #
      def nodetool_ring
-       @nodetool_ring ||= DaemonRunner::ShellOut.new(command: 'nodetool ring', timeout: 120)
+       @nodetool_ring ||= DaemonRunner::ShellOut.new(command: 'nodetool ring', timeout: 300)
        @nodetool_ring.run!
        @nodetool_ring.stdout
      end
@@ -168,7 +168,7 @@ module Cassandra
      # @return [String, nil] Output from the "nodetool status" command
      #
      def nodetool_status
-       @nodetool_status ||= DaemonRunner::ShellOut.new(command: 'nodetool status', timeout: 120)
+       @nodetool_status ||= DaemonRunner::ShellOut.new(command: 'nodetool status', timeout: 300)
        @nodetool_status.run!
        @nodetool_status.stdout
      end
@@ -178,7 +178,7 @@ module Cassandra
      # @return [String, nil] Output from the "nodetool netstats" command
      #
      def nodetool_netstats
-       @nodetool_netstats ||= DaemonRunner::ShellOut.new(command: 'nodetool netstats', timeout: 120)
+       @nodetool_netstats ||= DaemonRunner::ShellOut.new(command: 'nodetool netstats', timeout: 300)
        @nodetool_netstats.run!
        @nodetool_netstats.stdout
      end

--- a/lib/cassandra/utils/cli/base.rb
+++ b/lib/cassandra/utils/cli/base.rb
@@ -12,7 +12,7 @@ module Cassandra
         end
 
         def timeout
-          15
+          300
         end
 
         def runner

--- a/lib/cassandra/utils/stats/cleanup.rb
+++ b/lib/cassandra/utils/stats/cleanup.rb
@@ -15,6 +15,10 @@ module Cassandra
         def metric_name
           'cassandra.cleanup.running'
         end
+
+        def task_id
+          ['cleanup', 'nodetool']
+        end
       end
     end
   end

--- a/lib/cassandra/utils/stats/compaction.rb
+++ b/lib/cassandra/utils/stats/compaction.rb
@@ -15,6 +15,10 @@ module Cassandra
         def metric_name
           'cassandra.compaction.running'
         end
+
+        def task_id
+          ['compaction', 'nodetool']
+        end
       end
     end
   end

--- a/lib/cassandra/utils/stats/health.rb
+++ b/lib/cassandra/utils/stats/health.rb
@@ -33,6 +33,10 @@ module Cassandra
           results.first.strip.downcase.to_sym
         end
 
+        def task_id
+          ['health', 'nodetool']
+        end
+
         private
 
         # Run the "nodetool statusgossip' command and return the output
@@ -63,10 +67,6 @@ module Cassandra
           @nodetool_netstats ||= DaemonRunner::ShellOut.new(command: 'nodetool netstats', timeout: 300)
           @nodetool_netstats.run!
           @nodetool_netstats.stdout
-        end
-
-        def task_id
-          ['health', 'nodetool']
         end
       end
     end

--- a/lib/cassandra/utils/stats/health.rb
+++ b/lib/cassandra/utils/stats/health.rb
@@ -60,7 +60,7 @@ module Cassandra
         # @return [String, nil] Output from the "nodetool netstats" command
         #
         def nodetool_netstats
-          @nodetool_netstats ||= DaemonRunner::ShellOut.new(command: 'nodetool netstats', timeout: 120)
+          @nodetool_netstats ||= DaemonRunner::ShellOut.new(command: 'nodetool netstats', timeout: 300)
           @nodetool_netstats.run!
           @nodetool_netstats.stdout
         end

--- a/lib/cassandra/utils/stats/health.rb
+++ b/lib/cassandra/utils/stats/health.rb
@@ -64,6 +64,10 @@ module Cassandra
           @nodetool_netstats.run!
           @nodetool_netstats.stdout
         end
+
+        def task_id
+          ['health', 'nodetool']
+        end
       end
     end
   end


### PR DESCRIPTION
This change tries to address `nodetool` timeouts by increasing the timeout and putting all of the tasks that use `nodetool` in a shared mutex.

Note: The `nodetool` timeouts were really fixed by rapid7/daemon_runner#33