### PR TITLE
Fix: Don't cache Mixlib::ShellOut

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,8 @@ GIT
 PATH
   remote: .
   specs:
-    cassandra-utils (0.2.4)
-      daemon_runner (~> 0.2)
+    cassandra-utils (0.0.1)
+      daemon_runner (~> 0.4)
       dogstatsd-ruby (~> 1.6)
       mixlib-shellout (~> 2.2)
       thor (~> 0.19)
@@ -19,7 +19,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    daemon_runner (0.4.1)
+    daemon_runner (0.4.2)
       diplomat (~> 1.0)
       logging (~> 2.1)
       mixlib-shellout (~> 2.2)

--- a/cassandra-utils.gemspec
+++ b/cassandra-utils.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "mixlib-shellout", "~> 2.2"
   spec.add_dependency "dogstatsd-ruby", "~> 1.6"
   spec.add_dependency "thor", "~> 0.19"
-  spec.add_dependency "daemon_runner", "~> 0.2"
+  spec.add_dependency "daemon_runner", "~> 0.4"
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/cassandra/utils/cli/base.rb
+++ b/lib/cassandra/utils/cli/base.rb
@@ -1,4 +1,4 @@
-require 'mixlib/shellout'
+require 'daemon_runner/shell_out'
 
 module Cassandra
   module Utils
@@ -15,7 +15,7 @@ module Cassandra
         end
 
         def runner
-          @command ||= Mixlib::ShellOut.new(command, :cwd => cwd, :timeout => timeout)
+          @command ||= DaemonRunner::ShellOut.new(command, :cwd => cwd, :timeout => timeout)
         end
 
         def output


### PR DESCRIPTION
This fixes #15 by switching `Mixlib::ShellOut` to `DaemonRunner::ShellOut`. The [`daemon_runner` gem\(https://github.com/rapid7/daemon_runner) does the right thing and doesn't cache the `Mixlib::ShellOut` instance between executions.