### PR TITLE
Fix: Base metric reporting

### DIFF
--- a/lib/cassandra/utils/cli/base.rb
+++ b/lib/cassandra/utils/cli/base.rb
@@ -15,7 +15,7 @@ module Cassandra
         end
 
         def runner
-          @command ||= DaemonRunner::ShellOut.new(command, :cwd => cwd, :timeout => timeout)
+          @command ||= DaemonRunner::ShellOut.new(command: command, cwd: cwd, timeout: timeout)
         end
 
         def output

--- a/lib/cassandra/utils/cli/base.rb
+++ b/lib/cassandra/utils/cli/base.rb
@@ -24,8 +24,7 @@ module Cassandra
 
         def run!
           runner
-          @command.run_command
-          @command.error!
+          @command.run!
           @stdout = @command.stdout
           out = output
           Utils::Statsd.new(metric_name).to_dd(out).push!

--- a/test/cassandra/cleanup_check_test.rb
+++ b/test/cassandra/cleanup_check_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+describe Cassandra::Utils::Stats::Cleanup do
+  before do
+    @cleanup = Cassandra::Utils::Stats::Cleanup.new
+  end
+
+  it 'succeeds if cleanup is running' do
+    @cleanup.run!.must_equal true
+  end
+end

--- a/test/cassandra/cleanup_check_test.rb
+++ b/test/cassandra/cleanup_check_test.rb
@@ -1,19 +1,5 @@
 require 'test_helper'
-
-class MockShellOut
-  attr_reader :stdout
-  attr_accessor :valid_exit_codes
-
-  def initialize(stdout)
-    @stdout = stdout
-  end
-
-  def run_command
-  end
-
-  def error!
-  end
-end
+require 'mock_shell_out'
 
 describe Cassandra::Utils::Stats::Cleanup do
   before do

--- a/test/cassandra/cleanup_check_test.rb
+++ b/test/cassandra/cleanup_check_test.rb
@@ -1,11 +1,41 @@
 require 'test_helper'
 
+class MockShellOut
+  attr_reader :stdout
+  attr_accessor :valid_exit_codes
+
+  def initialize(stdout)
+    @stdout = stdout
+  end
+
+  def run_command
+  end
+
+  def error!
+  end
+end
+
 describe Cassandra::Utils::Stats::Cleanup do
   before do
     @cleanup = Cassandra::Utils::Stats::Cleanup.new
   end
 
   it 'succeeds if cleanup is running' do
-    @cleanup.run!.must_equal true
+    shellout = lambda do |command, options|
+      command.must_equal 'nodetool compactionstats'
+
+      results = <<-END
+      pending tasks: 1
+                compaction type  keyspace  table  completed  total  unit  progress
+                        Cleanup  test      test   3          100    bytes    3.14%
+      Active compaction remaining time : 0h03m14s
+      END
+
+      MockShellOut.new(results)
+    end
+
+    Mixlib::ShellOut.stub :new, shellout do
+      @cleanup.run!.must_equal true
+    end
   end
 end

--- a/test/cassandra/cleanup_check_test.rb
+++ b/test/cassandra/cleanup_check_test.rb
@@ -38,4 +38,21 @@ describe Cassandra::Utils::Stats::Cleanup do
       @cleanup.run!.must_equal true
     end
   end
+
+  it 'fails if cleanup is not running' do
+    shellout = lambda do |command, options|
+      command.must_equal 'nodetool compactionstats'
+
+      results = <<-END
+      pending tasks: 0
+      Active compaction remaining time : n/a
+      END
+
+      MockShellOut.new(results)
+    end
+
+    Mixlib::ShellOut.stub :new, shellout do
+      @cleanup.run!.must_equal false
+    end
+  end
 end

--- a/test/cassandra/compaction_check_test.rb
+++ b/test/cassandra/compaction_check_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class MockShellOut
+  attr_reader :stdout
+  attr_accessor :valid_exit_codes
+
+  def initialize(stdout)
+    @stdout = stdout
+  end
+
+  def run_command
+  end
+
+  def error!
+  end
+end
+
+describe Cassandra::Utils::Stats::Compaction do
+  before do
+    @compactor = Cassandra::Utils::Stats::Compaction.new
+  end
+
+  it 'succeeds if compaction is running' do
+    shellout = lambda do |command, options|
+      command.must_equal 'nodetool compactionstats'
+
+      results = <<-END
+      pending tasks: 1
+                compaction type  keyspace  table  completed  total  unit  progress
+                      Compaction test      test   3          100    bytes    3.14%
+      Active compaction remaining time : 0h03m14s
+      END
+
+      MockShellOut.new(results)
+    end
+
+    Mixlib::ShellOut.stub :new, shellout do
+      @compactor.run!.must_equal true
+    end
+  end
+
+  it 'fails if compaction is not running' do
+    shellout = lambda do |command, options|
+      command.must_equal 'nodetool compactionstats'
+
+      results = <<-END
+      pending tasks: 0
+      Active compaction remaining time : n/a
+      END
+
+      MockShellOut.new(results)
+    end
+
+    Mixlib::ShellOut.stub :new, shellout do
+      @compactor.run!.must_equal false
+    end
+  end
+end

--- a/test/cassandra/compaction_check_test.rb
+++ b/test/cassandra/compaction_check_test.rb
@@ -1,19 +1,5 @@
 require 'test_helper'
-
-class MockShellOut
-  attr_reader :stdout
-  attr_accessor :valid_exit_codes
-
-  def initialize(stdout)
-    @stdout = stdout
-  end
-
-  def run_command
-  end
-
-  def error!
-  end
-end
+require 'mock_shell_out'
 
 describe Cassandra::Utils::Stats::Compaction do
   before do

--- a/test/mock_shell_out.rb
+++ b/test/mock_shell_out.rb
@@ -1,0 +1,14 @@
+class MockShellOut
+  attr_reader :stdout
+  attr_accessor :valid_exit_codes
+
+  def initialize(stdout)
+    @stdout = stdout
+  end
+
+  def run_command
+  end
+
+  def error!
+  end
+end


### PR DESCRIPTION
This fixes #22. Stats for compaction and cleanup are now reported correctly. Additionally, there are tests in place for those metric collectors.