### PR TITLE
Feature: Consul seed registry

### DIFF
--- a/bin/cass-util
+++ b/bin/cass-util
@@ -14,6 +14,9 @@ class CassandraUtils < Thor
   class_option :cleanup_lock_count, type: :numeric,
     required: true, default: 1,
     desc: 'Number of nodes that can obtain a Semaphore lock'
+  class_option :seed_service_name, type: :string,
+    required: true, default: 'cassandra',
+    desc: 'Unique string to be used in obtaining a Consul seed lock. Example: cassandra-seed-#{cluster_name}'
   desc 'util', 'Perform various utilities'
   def util
     s = ::Cassandra::Utils::Daemon.new(options)

--- a/lib/cassandra/tasks.rb
+++ b/lib/cassandra/tasks.rb
@@ -1,1 +1,2 @@
 require_relative 'tasks/autoclean'
+require_relative 'tasks/seedregistry'

--- a/lib/cassandra/tasks/seedregistry.rb
+++ b/lib/cassandra/tasks/seedregistry.rb
@@ -14,6 +14,15 @@ module Cassandra
        raise ArgumentError.new('cluster_name must not be empty') if @cluster_name.empty?
      end
 
+     # Return true if the Cassandra node is a valid seed, false otherwise
+     #
+     # @return [Boolean]
+     #
+     def can_seed?
+       return false unless state == :normal
+       true
+     end
+
      # Return the state of the Cassandra node
      #
      # The returned state is reported by "nodetool netstats".

--- a/lib/cassandra/tasks/seedregistry.rb
+++ b/lib/cassandra/tasks/seedregistry.rb
@@ -21,7 +21,7 @@ module Cassandra
      # Schedule the seed registration process to run periodically
      #
      def schedule
-       [:interval, '10m']
+       [:interval, '10s']
      end
 
      # Get a lock in Consul registering the Cassandra node as a seed

--- a/lib/cassandra/tasks/seedregistry.rb
+++ b/lib/cassandra/tasks/seedregistry.rb
@@ -1,0 +1,16 @@
+module Cassandra
+  module Tasks
+   class SeedRegistry
+     # Create a new SeedRegistry task
+     #
+     # @param cluster_name [String] unique name (in Consul) for the Cassandra cluster
+     #
+     # @return [SeedRegistry]
+     #
+     def initialize cluster_name
+       @cluster_name = cluster_name.to_s
+       raise ArgumentError.new('cluster_name must not be empty') if @cluster_name.empty?
+     end
+   end
+  end
+end

--- a/lib/cassandra/tasks/seedregistry.rb
+++ b/lib/cassandra/tasks/seedregistry.rb
@@ -1,3 +1,5 @@
+require 'daemon_runner/shell_out'
+
 module Cassandra
   module Tasks
    class SeedRegistry
@@ -10,6 +12,28 @@ module Cassandra
      def initialize cluster_name
        @cluster_name = cluster_name.to_s
        raise ArgumentError.new('cluster_name must not be empty') if @cluster_name.empty?
+     end
+
+     def data_center
+       results = (nodetool_info || '').split("\n")
+       results.map! { |line| line.strip }
+       results.select! { |line| line.include?('Data Center') }
+       results.map! { |line| line.split(':')[1] }
+       results.compact!
+       return nil if results.size != 1
+       results.first.strip
+     end
+
+     private
+
+     # Run the "nodetool info" command and return the output
+     #
+     # @return [String, nil] Output from the "nodetool info" command
+     #
+     def nodetool_info
+       @nodetool_info ||= DaemonRunner::ShellOut.new(command: 'nodetool info', timeout: 300)
+       @nodetool_info.run!
+       @nodetool_info.stdout
      end
    end
   end

--- a/lib/cassandra/tasks/seedregistry.rb
+++ b/lib/cassandra/tasks/seedregistry.rb
@@ -14,6 +14,22 @@ module Cassandra
        raise ArgumentError.new('cluster_name must not be empty') if @cluster_name.empty?
      end
 
+     # Return the state of the Cassandra node
+     #
+     # The returned state is reported by "nodetool netstats".
+     #
+     # @return [state, nil]
+     #
+     def state
+       results = (nodetool_netstats || '').split("\n")
+       results.map! { |line| line.strip }
+       results.select! { |line| line.include? 'Mode:' }
+       results.map! { |line| line.split(':')[1] }
+       results.compact!
+       return nil if results.size != 1
+       results.first.strip.downcase.to_sym
+     end
+
      # Return the data center the Cassandra node is in
      #
      # The returned data center is reported by "nodetool info".
@@ -56,6 +72,16 @@ module Cassandra
        @nodetool_info ||= DaemonRunner::ShellOut.new(command: 'nodetool info', timeout: 300)
        @nodetool_info.run!
        @nodetool_info.stdout
+     end
+
+     # Run the "nodetool netstats" command and return the output
+     #
+     # @return [String, nil] Output from the "nodetool netstats" command
+     #
+     def nodetool_netstats
+       @nodetool_netstats ||= DaemonRunner::ShellOut.new(command: 'nodetool netstats', timeout: 300)
+       @nodetool_netstats.run!
+       @nodetool_netstats.stdout
      end
    end
   end

--- a/lib/cassandra/tasks/seedregistry.rb
+++ b/lib/cassandra/tasks/seedregistry.rb
@@ -14,6 +14,12 @@ module Cassandra
        raise ArgumentError.new('cluster_name must not be empty') if @cluster_name.empty?
      end
 
+     # Return the data center the Cassandra node is in
+     #
+     # The returned data center is reported by "nodetool info".
+     #
+     # @return [String, nil]
+     #
      def data_center
        results = (nodetool_info || '').split("\n")
        results.map! { |line| line.strip }

--- a/lib/cassandra/tasks/seedregistry.rb
+++ b/lib/cassandra/tasks/seedregistry.rb
@@ -24,6 +24,22 @@ module Cassandra
        results.first.strip
      end
 
+     # Return the rack the Cassandra node is in
+     #
+     # The returned rack is reported by "nodetool info".
+     #
+     # @return [String, nil]
+     #
+     def rack
+       results = (nodetool_info || '').split("\n")
+       results.map! { |line| line.strip }
+       results.select! { |line| line.include?('Rack') }
+       results.map! { |line| line.split(':')[1] }
+       results.compact!
+       return nil if results.size != 1
+       results.first.strip
+     end
+
      private
 
      # Run the "nodetool info" command and return the output

--- a/lib/cassandra/tasks/seedregistry.rb
+++ b/lib/cassandra/tasks/seedregistry.rb
@@ -17,7 +17,7 @@ module Cassandra
        @renew_thread = nil
      end
 
-     # Schedule the sedd registration process to run periodically
+     # Schedule the seed registration process to run periodically
      #
      def schedule
        [:interval, '10m']

--- a/lib/cassandra/tasks/seedregistry.rb
+++ b/lib/cassandra/tasks/seedregistry.rb
@@ -121,13 +121,12 @@ module Cassandra
 
      # Return cached output from "nodetool info" command
      #
+     # This will attempt to populate an empty cache by calling "nodetool info".
+     #
      # @return [String, nil] Cached output from the "nodetool info" command
      #
      def nodetool_info_cached
-       if @nodetool_info_cache.nil?
-         @nodetool_info_cache = nodetool_info
-       end
-       @nodetool_info_cache
+       @nodetool_info_cache ||= nodetool_info
      end
 
      # Run the "nodetool netstats" command and return the output

--- a/lib/cassandra/tasks/seedregistry.rb
+++ b/lib/cassandra/tasks/seedregistry.rb
@@ -17,6 +17,12 @@ module Cassandra
        @renew_thread = nil
      end
 
+     # Schedule the sedd registration process to run periodically
+     #
+     def schedule
+       [:interval, '10m']
+     end
+
      # Get a lock in Consul registering the Cassandra node as a seed
      #
      def run!

--- a/lib/cassandra/utils/daemon.rb
+++ b/lib/cassandra/utils/daemon.rb
@@ -6,6 +6,7 @@ module Cassandra
 
       def tasks
         [
+          [seed_registry_task, 'run!'],
           [auto_clean_task, 'run!'],
           [health_stat, 'run!'],
           [compaction_stat, 'run!'],
@@ -14,6 +15,11 @@ module Cassandra
       end
 
       private
+
+      def seed_registry_task
+        name = options[:seed_service_name]
+        @seed_registry_task ||= ::Cassandra::Tasks::SeedRegistry.new(name)
+      end
 
       def auto_clean_task
         @auto_clean_task ||= ::Cassandra::Tasks::Autoclean.new(options)

--- a/test/cassandra/seedregistry_test.rb
+++ b/test/cassandra/seedregistry_test.rb
@@ -1,5 +1,20 @@
 require 'test_helper'
 
+class MockShellOut
+  attr_reader :stdout
+  attr_accessor :valid_exit_codes
+
+  def initialize(stdout)
+    @stdout = stdout
+  end
+
+  def run_command
+  end
+
+  def error!
+  end
+end
+
 describe Cassandra::Tasks::SeedRegistry do
   describe :new do
     it 'requires a non-nil cluster name' do
@@ -8,6 +23,40 @@ describe Cassandra::Tasks::SeedRegistry do
 
     it 'requires a non-empty cluster name' do
       proc { Cassandra::Tasks::SeedRegistry.new('') }.must_raise ArgumentError
+    end
+  end
+
+  describe :data_center do
+    it 'returns the data center for this node' do
+      shellout = lambda do |command, options|
+        command.must_equal 'nodetool info'
+
+        results = <<-END
+        Token                  : (invoke with -T/--tokens to see all 256 tokens)
+        ID                     : uuid
+        Gossip active          : true
+        Thrift active          : true
+        Native Transport active: true
+        Load                   : 0.0 GB
+        Generation No          : 0
+        Uptime (seconds)       : 0
+        Heap Memory (MB)       : 0 / 0
+        Off Heap Memory (MB)   : 0
+        Data Center            : us-east
+        Rack                   : 1d
+        Exceptions             : 0
+        Key Cache              : size 0 (bytes), capacity 0 (bytes), 0 hits, 0 requests, NaN recent hit rate, 0 save period in seconds
+        Row Cache              : size 0 (bytes), capacity 0 (bytes), 0 hits, 0 requests, NaN recent hit rate, 0 save period in seconds
+        END
+
+        MockShellOut.new(results)
+      end
+
+      registry = Cassandra::Tasks::SeedRegistry.new('test')
+
+      Mixlib::ShellOut.stub :new, shellout do
+        registry.data_center.must_equal 'us-east'
+      end
     end
   end
 end

--- a/test/cassandra/seedregistry_test.rb
+++ b/test/cassandra/seedregistry_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+describe Cassandra::Tasks::SeedRegistry do
+  describe :new do
+    it 'requires a non-nil cluster name' do
+      proc { Cassandra::Tasks::SeedRegistry.new(nil) }.must_raise ArgumentError
+    end
+
+    it 'requires a non-empty cluster name' do
+      proc { Cassandra::Tasks::SeedRegistry.new('') }.must_raise ArgumentError
+    end
+  end
+end

--- a/test/cassandra/seedregistry_test.rb
+++ b/test/cassandra/seedregistry_test.rb
@@ -14,7 +14,13 @@ describe Cassandra::Tasks::SeedRegistry do
   end
 
   def nodetool_info_mock(options = {})
-    options = {data_center: 'us-east', rack: '1d'}.merge(options)
+    options = {
+      gossip: true,
+      thrift: true,
+      native: true,
+      data_center: 'us-east',
+      rack: '1d'
+    }.merge(options)
     if options[:data_center]
       options[:data_center] = "Data Center : #{options[:data_center]}"
     end
@@ -28,9 +34,9 @@ describe Cassandra::Tasks::SeedRegistry do
       results = <<-END
       Token                  : (invoke with -T/--tokens to see all 256 tokens)
       ID                     : uuid
-      Gossip active          : true
-      Thrift active          : true
-      Native Transport active: true
+      Gossip active          : #{options[:gossip]}
+      Thrift active          : #{options[:thrift]}
+      Native Transport active: #{options[:native]}
       Load                   : 0.0 GB
       Generation No          : 0
       Uptime (seconds)       : 0

--- a/test/cassandra/seedregistry_test.rb
+++ b/test/cassandra/seedregistry_test.rb
@@ -59,4 +59,38 @@ describe Cassandra::Tasks::SeedRegistry do
       end
     end
   end
+
+  describe :rack do
+    it 'returns the rack for this node' do
+      shellout = lambda do |command, options|
+        command.must_equal 'nodetool info'
+
+        results = <<-END
+        Token                  : (invoke with -T/--tokens to see all 256 tokens)
+        ID                     : uuid
+        Gossip active          : true
+        Thrift active          : true
+        Native Transport active: true
+        Load                   : 0.0 GB
+        Generation No          : 0
+        Uptime (seconds)       : 0
+        Heap Memory (MB)       : 0 / 0
+        Off Heap Memory (MB)   : 0
+        Data Center            : us-east
+        Rack                   : 1d
+        Exceptions             : 0
+        Key Cache              : size 0 (bytes), capacity 0 (bytes), 0 hits, 0 requests, NaN recent hit rate, 0 save period in seconds
+        Row Cache              : size 0 (bytes), capacity 0 (bytes), 0 hits, 0 requests, NaN recent hit rate, 0 save period in seconds
+        END
+
+        MockShellOut.new(results)
+      end
+
+      registry = Cassandra::Tasks::SeedRegistry.new('test')
+
+      Mixlib::ShellOut.stub :new, shellout do
+        registry.rack.must_equal '1d'
+      end
+    end
+  end
 end

--- a/test/cassandra/seedregistry_test.rb
+++ b/test/cassandra/seedregistry_test.rb
@@ -1,20 +1,6 @@
 require 'test_helper'
 require 'securerandom'
-
-class MockShellOut
-  attr_reader :stdout
-  attr_accessor :valid_exit_codes
-
-  def initialize(stdout)
-    @stdout = stdout
-  end
-
-  def run_command
-  end
-
-  def error!
-  end
-end
+require 'mock_shell_out'
 
 describe Cassandra::Tasks::SeedRegistry do
   describe :new do

--- a/test/cassandra/seedregistry_test.rb
+++ b/test/cassandra/seedregistry_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'securerandom'
 
 class MockShellOut
   attr_reader :stdout
@@ -59,9 +60,10 @@ describe Cassandra::Tasks::SeedRegistry do
   describe :data_center do
     it 'returns the data center for this node' do
       registry = Cassandra::Tasks::SeedRegistry.new('test')
+      data_center = SecureRandom.hex[0..10]
 
-      Mixlib::ShellOut.stub :new, nodetool_info_mock do
-        registry.data_center.must_equal 'us-east'
+      Mixlib::ShellOut.stub :new, nodetool_info_mock(data_center: data_center) do
+        registry.data_center.must_equal data_center
       end
     end
   end
@@ -69,9 +71,10 @@ describe Cassandra::Tasks::SeedRegistry do
   describe :rack do
     it 'returns the rack for this node' do
       registry = Cassandra::Tasks::SeedRegistry.new('test')
+      rack = SecureRandom.hex[0..10]
 
-      Mixlib::ShellOut.stub :new, nodetool_info_mock do
-        registry.rack.must_equal '1d'
+      Mixlib::ShellOut.stub :new, nodetool_info_mock(rack: rack) do
+        registry.rack.must_equal rack
       end
     end
   end

--- a/test/cassandra/seedregistry_test.rb
+++ b/test/cassandra/seedregistry_test.rb
@@ -139,4 +139,16 @@ describe Cassandra::Tasks::SeedRegistry do
       end
     end
   end
+
+  describe :can_seed? do
+    it 'is false unless the node state is NORMAL' do
+      registry = Cassandra::Tasks::SeedRegistry.new('test')
+
+      [:moving, :joining, :leaving].each do |state|
+        registry.stub :state, state do
+          registry.can_seed?.must_equal false
+        end
+      end
+    end
+  end
 end

--- a/test/mock_semaphore.rb
+++ b/test/mock_semaphore.rb
@@ -1,0 +1,46 @@
+class MockSemaphore
+  attr_reader :lock_call_count
+  attr_reader :renew_call_count
+  attr_reader :kill_call_count
+  attr_reader :locked_call_count
+  attr_reader :try_release_count
+
+  def initialize
+    @lock_call_count = 0
+    @renew_call_count = 0
+    @kill_call_count = 0
+    @locked_call_count = 0
+    @try_release_count = 0
+    @is_locked = false
+  end
+
+  def lock
+    @is_locked = true
+    @lock_call_count += 1
+    nil
+  end
+
+  def renew
+    @renew_call_count += 1
+    self
+  end
+
+  def locked?
+    @locked_call_count += 1
+    @is_locked
+  end
+
+  def try_release
+    @try_release_count += 1
+    @is_locked = false
+    nil
+  end
+
+  def kill
+    @kill_call_count += 1
+    nil
+  end
+
+  def validate!
+  end
+end


### PR DESCRIPTION
This establishes a seed registry with Consul. The idea is that nodes get a lock on a "cluster/data-center-rack/.lock" key. Doing a recursive read on the "cluster/" key then gives you all the seed nodes (one per data-center + rack pair).

A node is a valid seed candidate (can try to get the lock in Consul for its data-center + rack) if it's in a normal state (as reported by `nodetool netstats`) and gossip, thrift, and the native protocol are running (as reported by `nodetool info`).