### PR TITLE
Fix: Better autoclean logging

### DIFF
--- a/lib/cassandra/tasks/autoclean.rb
+++ b/lib/cassandra/tasks/autoclean.rb
@@ -88,7 +88,10 @@ module Cassandra
 
        new_tokens = Set.new tokens
        old_tokens = Set.new cached_tokens
-       return if new_tokens == old_tokens
+       if new_tokens == old_tokens
+         logger.debug "Cleanup skipped because tokens haven't changed"
+         return
+       end
 
        ::DaemonRunner::Semaphore.lock(@service_name, @lock_count) do
          result = nodetool_cleanup

--- a/lib/cassandra/tasks/autoclean.rb
+++ b/lib/cassandra/tasks/autoclean.rb
@@ -106,8 +106,8 @@ module Cassandra
      def cached_tokens
        data = token_cache.read
        data = JSON.parse data
-       if data['version'] != ::Cassandra::Utils::VERSION
-         logger.debug "Failed to read cached tokens. Expected version #{::Cassandra::Utils::VERSION} got #{data['version']}"
+       unless data['version'] == ::Cassandra::Utils::VERSION
+         logger.debug "Failed to read cached tokens because version didn't match. Expected #{::Cassandra::Utils::VERSION} got #{data['version']}"
          return []
        end
 

--- a/lib/cassandra/tasks/autoclean.rb
+++ b/lib/cassandra/tasks/autoclean.rb
@@ -76,13 +76,13 @@ module Cassandra
      def run!
        node_status = status
        unless node_status == :up
-         logger.debug "Cleanup skipped because node status is not up: #{node_status}"
+         logger.debug "Cleanup skipped because of node status. Expected up got #{node_status}"
          return
        end
 
        node_state = state
        unless node_state == :normal
-         logger.debug "Cleanup skipped because node state is not normal: #{node_state}"
+         logger.debug "Cleanup skipped because of node state. Expected normal got #{node_state}"
          return
        end
 

--- a/lib/cassandra/tasks/autoclean.rb
+++ b/lib/cassandra/tasks/autoclean.rb
@@ -112,7 +112,11 @@ module Cassandra
        end
 
        tokens = data['tokens']
-       return [] if tokens.nil?
+       if tokens.nil?
+         logger.debug "Failed to read cached tokens because they're nil"
+         return []
+       end
+
        return [] unless tokens.respond_to? :each
 
        tokens.sort!

--- a/lib/cassandra/tasks/autoclean.rb
+++ b/lib/cassandra/tasks/autoclean.rb
@@ -125,7 +125,9 @@ module Cassandra
        tokens.sort!
        tokens
      # Token file could not be opend or parsed
-     rescue Errno::ENOENT, JSON::ParserError
+     rescue Errno::ENOENT, JSON::ParserError => e
+       logger.debug "Caught exception while reading cached tokens"
+       logger.debug e
        []
      end
 

--- a/lib/cassandra/tasks/autoclean.rb
+++ b/lib/cassandra/tasks/autoclean.rb
@@ -75,13 +75,13 @@ module Cassandra
      #
      def run!
        node_status = status
-       if node_status != :up
+       unless node_status == :up
          logger.debug "Cleanup skipped because node status is not up: #{node_status}"
          return
        end
 
        node_state = state
-       if node_state != :normal
+       unless node_state == :normal
          logger.debug "Cleanup skipped because node state is not normal: #{node_state}"
          return
        end

--- a/lib/cassandra/tasks/autoclean.rb
+++ b/lib/cassandra/tasks/autoclean.rb
@@ -106,7 +106,10 @@ module Cassandra
      def cached_tokens
        data = token_cache.read
        data = JSON.parse data
-       return [] unless data['version'] == ::Cassandra::Utils::VERSION
+       if data['version'] != ::Cassandra::Utils::VERSION
+         logger.debug "Failed to read cached tokens. Expected version #{::Cassandra::Utils::VERSION} got #{data['version']}"
+         return []
+       end
 
        tokens = data['tokens']
        return [] if tokens.nil?

--- a/lib/cassandra/tasks/autoclean.rb
+++ b/lib/cassandra/tasks/autoclean.rb
@@ -155,7 +155,11 @@ module Cassandra
      # @return [Array<String>] Tokens owned by this node
      #
      def tokens
-       return [] if address.nil?
+       if address.nil?
+         logger.debug "Failed to read live tokens because address is nil"
+         return []
+       end
+
        results = (nodetool_ring || '').split("\n")
        results.map! { |line| line.strip }
        results.select! { |line| line.start_with? address }

--- a/lib/cassandra/tasks/autoclean.rb
+++ b/lib/cassandra/tasks/autoclean.rb
@@ -117,7 +117,10 @@ module Cassandra
          return []
        end
 
-       return [] unless tokens.respond_to? :each
+       unless tokens.respond_to? :each
+         logger.debug "Failed to read cached tokens because they're invalid"
+         return []
+       end
 
        tokens.sort!
        tokens

--- a/lib/cassandra/tasks/autoclean.rb
+++ b/lib/cassandra/tasks/autoclean.rb
@@ -74,8 +74,17 @@ module Cassandra
      # Run the Cassandra cleanup process if necessary
      #
      def run!
-       return unless status == :up
-       return unless state == :normal
+       node_status = status
+       if node_status != :up
+         logger.debug "Cleanup skipped because node status is not up: #{node_status}"
+         return
+       end
+
+       node_state = state
+       if node_state != :normal
+         logger.debug "Cleanup skipped because node state is not normal: #{node_state}"
+         return
+       end
 
        new_tokens = Set.new tokens
        old_tokens = Set.new cached_tokens


### PR DESCRIPTION
This adds additional debug logging to the autoclean task. We're seeing issues on some clusters where cleanup will rerun even though no new nodes have been added to the cluster. The hope is that this additional logging lets us track down why that's happening.