### PR TITLE
Fix empty autoclean tokens file

### DIFF
--- a/lib/cassandra/tasks/autoclean.rb
+++ b/lib/cassandra/tasks/autoclean.rb
@@ -148,6 +148,13 @@ module Cassandra
          :version => ::Cassandra::Utils::VERSION
        }
 
+       if token_cache.closed?
+         logger.debug "Failed to save cached tokens because file is closed."
+         return []
+       end
+
+       token_cache.seek 0
+       token_cache.truncate 0
        token_cache.write data.to_json
      end
 

--- a/lib/cassandra/tasks/autoclean.rb
+++ b/lib/cassandra/tasks/autoclean.rb
@@ -104,8 +104,15 @@ module Cassandra
      # @return [Array<String>] Cached tokens
      #
      def cached_tokens
+       if token_cache.closed?
+         logger.debug "Failed to read cached tokens because file is closed."
+         return []
+       end
+
+       token_cache.seek 0
        data = token_cache.read
        data = JSON.parse data
+
        unless data['version'] == ::Cassandra::Utils::VERSION
          logger.debug "Failed to read cached tokens because version didn't match. Expected #{::Cassandra::Utils::VERSION} got #{data['version']}"
          return []

--- a/lib/cassandra/tasks/autoclean.rb
+++ b/lib/cassandra/tasks/autoclean.rb
@@ -142,7 +142,6 @@ module Cassandra
        }
 
        token_cache.write data.to_json
-       token_cache.flush
      end
 
      # Get the tokens this node owns

--- a/lib/cassandra/tasks/autoclean.rb
+++ b/lib/cassandra/tasks/autoclean.rb
@@ -279,7 +279,8 @@ module Cassandra
      # @return [File] File where tokens wil be saved
      #
      def token_cache
-       File.new(token_cache_path, 'w+')
+       mode = File::CREAT | File::RDWR | File::SYNC
+       @token_cache ||= File.new(token_cache_path, mode)
      end
    end
   end


### PR DESCRIPTION
This fixes #26. We now create a tokens file with the correct read/write/sync bits set. We seek to the beginning of the file when reading, so we read any new tokens. We also seek to the beginning of the file (and truncate it) when writing, so we overwrite an old tokens. There are additional checks in place to ensure the file's not closed before trying to read or write to it.